### PR TITLE
Server: Admin: Add note to attribute screen indicating parent-child status

### DIFF
--- a/global_finprint/annotation/models/annotation.py
+++ b/global_finprint/annotation/models/annotation.py
@@ -10,7 +10,7 @@ class Attribute(MPTTModel):
         help_text='overridden if parent is inactive')
     lead_only = models.BooleanField(
         default=False,
-        help_text='overridden if parent is lead_only')
+        help_text='overridden if parent is lead only')
 
     parent = TreeForeignKey('self', null=True, blank=True, related_name='children', db_index=True)
 


### PR DESCRIPTION
Adds some help text to let the user know how 'active' and lead_only' fields are affected by parent attributes. Easy to change if we need to clarify further.
